### PR TITLE
[SRE-867] do not drop changes from the buffer in a panic situation

### DIFF
--- a/src/change_processing.rs
+++ b/src/change_processing.rs
@@ -1,10 +1,12 @@
 use crate::parser::{
-    ChangeKind, Column, ColumnInfo, ColumnName, ColumnType, ColumnValue, ParsedLine, TableName,
+    ChangeKind, Column, ColumnInfo, ColumnName, ColumnType, ColumnValue, ParsedLine, TableName, ParsingError
 };
 use crate::targets_tables_column_names::{Table as TableFromTarget, TargetsTablesColumnNames};
 use crate::wal_file_manager::WalFile;
 use itertools::Itertools;
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::hash_map::Entry::{Occupied, Vacant};
+use std::{error::Error, fmt};
 
 use crate::file_writer;
 use either::Either;
@@ -35,6 +37,32 @@ impl std::string::ToString for DdlChange {
         }
     }
 }
+
+#[derive(Debug)]
+struct ChangeProcessingError {
+    parsed_line: Option<ParsedLine>,
+    message: String,
+    source_line: Option<String>
+}
+
+impl Error for ChangeProcessingError {}
+
+impl fmt::Display for ChangeProcessingError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Failed to process changes due to: {}, Offending source line: {:?}, Offending parsed line: {:?}",
+        self.message,
+        self.source_line,
+        self.parsed_line)
+    }
+}
+
+impl From<ParsingError> for ChangeProcessingError {
+    fn from(err: ParsingError) -> ChangeProcessingError {
+        ChangeProcessingError{ source_line: Some(err.line), message: err.message, parsed_line: None }
+    }
+}
+
+pub type Result<T> = std::result::Result<T, ChangeProcessingError>;
 
 #[derive(Debug, Eq, PartialEq)]
 struct ChangeSet {
@@ -69,18 +97,19 @@ impl ChangeSet {
         ChangeSet { changes: None }
     }
     // batch apply enabled
-    fn add_change(&mut self, new_change: ParsedLine) {
+    fn add_change(&mut self, new_change: ParsedLine) -> Result<()> {
         self.changes = match self.changes {
             Some(ParsedLine::ChangedData { kind, .. }) => match kind {
-                ChangeKind::Insert => self.handle_insert_subsequent(new_change),
-                ChangeKind::Update => self.handle_update_subsequent(new_change),
-                ChangeKind::Delete => self.handle_delete_subsequent(new_change),
+                ChangeKind::Insert => self.handle_insert_subsequent(new_change)?,
+                ChangeKind::Update => self.handle_update_subsequent(new_change)?,
+                ChangeKind::Delete => self.handle_delete_subsequent(new_change)?,
             },
             _ => Some(new_change),
-        }
+        };
+        Ok(())
     }
 
-    fn handle_insert_subsequent(&self, new_change: ParsedLine) -> Option<ParsedLine> {
+    fn handle_insert_subsequent(&self, new_change: ParsedLine) -> Result<Option<ParsedLine>> {
         if let ParsedLine::ChangedData {
             kind,
             columns,
@@ -88,37 +117,37 @@ impl ChangeSet {
         } = new_change
         {
             match kind {
-                ChangeKind::Insert => panic!("attempting to insert a record twice"),
+                ChangeKind::Insert => Err(ChangeProcessingError{ message: "attempting to insert a record twice".to_string(), parsed_line: Some(new_change.clone()), source_line: None }),
                 ChangeKind::Update => {
                     self.untoasted_changes(columns, table_name, ChangeKind::Insert)
                 }
-                ChangeKind::Delete => None,
+                ChangeKind::Delete => Ok(None),
             }
         } else {
-            panic!("don't know how to handle this type of line here")
+            Err(ChangeProcessingError{ message: "don't know how to handle this type of line here".to_string(), parsed_line: Some(new_change.clone()), source_line: None })
         }
     }
 
-    fn handle_update_subsequent(&self, new_change: ParsedLine) -> Option<ParsedLine> {
+    fn handle_update_subsequent(&self, new_change: ParsedLine) -> Result<Option<ParsedLine>> {
         if let ParsedLine::ChangedData { kind, .. } = new_change {
             match kind {
-                ChangeKind::Insert => panic!("attempting to insert a record twice"),
+                ChangeKind::Insert => Err(ChangeProcessingError{ message: "attempting to insert a record twice".to_string(), parsed_line: Some(new_change.clone()), source_line: None }),
                 ChangeKind::Update => match new_change {
                     ParsedLine::ChangedData {
                         columns,
                         table_name,
                         ..
                     } => self.untoasted_changes(columns, table_name, ChangeKind::Update),
-                    _ => panic!("don't know how to handle this type of line here"),
+                    _ => Err(ChangeProcessingError{ message: "don't know how to handle this type of line here".to_string(), parsed_line: Some(new_change.clone()), source_line: None })
                 },
-                ChangeKind::Delete => Some(new_change),
+                ChangeKind::Delete => Ok(Some(new_change)),
             }
         } else {
-            panic!("don't know how to handle this type of line here")
+            Err(ChangeProcessingError{ message: "don't know how to handle this type of line here".to_string(), parsed_line: Some(new_change.clone()), source_line: None })
         }
     }
 
-    fn handle_delete_subsequent(&self, new_change: ParsedLine) -> Option<ParsedLine> {
+    fn handle_delete_subsequent(&self, new_change: ParsedLine) -> Result<Option<ParsedLine>> {
         if let ParsedLine::ChangedData {
             kind,
             columns,
@@ -126,18 +155,18 @@ impl ChangeSet {
         } = new_change
         {
             match kind {
-                ChangeKind::Insert => Some(ParsedLine::ChangedData {
+                ChangeKind::Insert => Ok(Some(ParsedLine::ChangedData {
                     columns: columns,
                     kind: ChangeKind::Update,
                     table_name: table_name,
-                }),
+                })),
                 ChangeKind::Update => {
-                    panic!("attempting to update a record after it's been deleted")
-                }
-                ChangeKind::Delete => panic!("attempting to delete a record twice"),
+                    Err(ChangeProcessingError{ message: "attempting to update a record after it's been deleted".to_string(), parsed_line: Some(new_change.clone()), source_line: None })
+                },
+                ChangeKind::Delete => Err(ChangeProcessingError{ message: "attempting to delete a record twice".to_string(), parsed_line: Some(new_change.clone()), source_line: None }),
             }
         } else {
-            panic!("don't know how to handle this type of line here")
+            Err(ChangeProcessingError{ message: "don't know how to handle this type of line here".to_string(), parsed_line: Some(new_change.clone()), source_line: None })
         }
     }
 
@@ -146,20 +175,17 @@ impl ChangeSet {
         new_columns: Vec<Column>,
         table_name: TableName,
         new_kind: ChangeKind,
-    ) -> Option<ParsedLine> {
+    ) -> Result<Option<ParsedLine>> {
         if let Some(ParsedLine::ChangedData {
             columns: old_columns,
             ..
         }) = &self.changes
         {
-            assert_eq!(
+            fail_processing_if_unequal(
                 new_columns.len(),
                 old_columns.len(),
-                "discrepancy in number of columns for table {}: {} vs {}",
-                table_name,
-                new_columns.len(),
-                old_columns.len()
-            );
+                format!("discrepancy in number of columns for table {}: {} vs {}", table_name, new_columns.len(), old_columns.len())
+            )?;
             let untoasted_columns: Vec<Column> = new_columns
                 .iter()
                 .zip(old_columns.iter())
@@ -181,13 +207,13 @@ impl ChangeSet {
                 })
                 .collect();
 
-            Some(ParsedLine::ChangedData {
+            Ok(Some(ParsedLine::ChangedData {
                 columns: untoasted_columns,
                 kind: new_kind,
                 table_name: table_name,
-            })
+            }))
         } else {
-            panic!("last change was not changed data, no idea how we got here")
+            Err(ChangeProcessingError{ message: "last change was not changed data, no idea how we got here".to_string(), parsed_line: None, source_line: None })
         }
     }
 }
@@ -273,45 +299,42 @@ impl Table {
     fn new(
         parsed_line: &ParsedLine,
         targets_tables_column_names: &TargetsTablesColumnNames,
-    ) -> Table {
+    ) -> Result<Table> {
         if let ParsedLine::ChangedData { table_name, .. } = parsed_line {
-            let id_column = parsed_line.find_id_column().column_value_unwrap();
+            let id_column = parsed_line.find_id_column()?.column_value_unwrap();
             let changeset = ChangeSetWithColumnType::new(id_column);
             let column_info = None; // Don't trust the column info from the first parsed line as there might have been schema changes already
             let table_name = table_name.clone();
             let column_info_from_target =
                 targets_tables_column_names.get_by_name(&table_name.clone());
-            Table {
+            Ok(Table {
                 changeset,
                 column_info,
                 table_name,
                 column_info_from_target,
-            }
+            })
         } else {
-            panic!(
-                "Non changed data used to try and initialize a table {:?}",
-                parsed_line
-            )
+            Err(ChangeProcessingError{ message: "Non changed data used to try and initialize a table".to_string(), parsed_line: Some(parsed_line.clone()), source_line: None })
         }
     }
 
-    fn add_change(&mut self, parsed_line: ParsedLine) -> Option<(Table, Option<Vec<DdlChange>>)> {
+    fn add_change(&mut self, parsed_line: ParsedLine) -> Result<Option<(Table, Option<Vec<DdlChange>>)>> {
         if self.has_ddl_changes(&parsed_line) {
             // if we have ddl changes, send the table data off now, then send the ddl changes, then apply the change
-            let ddl_changes = self.ddl_changes(&parsed_line);
+            let ddl_changes = self.ddl_changes(&parsed_line)?;
             let returned_table = self.reset_and_return_table_data();
             // remember to update to the new column info, as this will be the new schema for after we return our ddl_changes
             self.column_info = parsed_line.column_info_set();
 
             // time_to_swap_tables is never true immediately after we add the first new change here
             // so we safely don't check it
-            self.add_change_to_changeset(parsed_line);
+            self.add_change_to_changeset(parsed_line)?;
 
-            Some((returned_table, Some(ddl_changes)))
+            Ok(Some((returned_table, Some(ddl_changes))))
         } else {
             // no ddl changes, add the line as normal
-            self.add_change_to_changeset(parsed_line);
-            None
+            self.add_change_to_changeset(parsed_line)?;
+            Ok(None)
         }
     }
 
@@ -328,10 +351,10 @@ impl Table {
         }
     }
 
-    fn add_change_to_changeset(&mut self, parsed_line: ParsedLine) {
+    fn add_change_to_changeset(&mut self, parsed_line: ParsedLine) -> Result<()> {
         self.update_column_info_if_unset(&parsed_line);
         if let ParsedLine::ChangedData { .. } = parsed_line {
-            let parsed_line_id = parsed_line.find_id_column();
+            let parsed_line_id = parsed_line.find_id_column()?;
             match parsed_line_id.column_value_unwrap() {
                 ColumnValue::Text(string) => {
                     if let ChangeSetWithColumnType::UuidColumnType(ref mut changeset) =
@@ -341,7 +364,7 @@ impl Table {
                         changeset
                             .entry(cloned)
                             .or_insert_with(|| ChangeSet::new())
-                            .add_change(parsed_line)
+                            .add_change(parsed_line)?
                     }
                 }
                 ColumnValue::Integer(int) => {
@@ -351,14 +374,15 @@ impl Table {
                         changeset
                             .entry(*int)
                             .or_insert_with(|| ChangeSet::new())
-                            .add_change(parsed_line)
+                            .add_change(parsed_line)?
                     }
                 }
-                _ => panic!("foobar"),
+                _ => return Err(ChangeProcessingError{ message: "Unhandled column value".to_string(), parsed_line: Some(parsed_line.clone()), source_line: None })
             };
         } else {
-            panic!("foobarbaz")
+            return Err(ChangeProcessingError{ message: "No changed data present".to_string(), parsed_line: Some(parsed_line.clone()), source_line: None })
         }
+        Ok(())
     }
 
     fn update_column_info_if_unset(&mut self, parsed_line: &ParsedLine) {
@@ -417,7 +441,7 @@ impl Table {
             .collect()
     }
 
-    fn ddl_changes(&self, parsed_line: &ParsedLine) -> Vec<DdlChange> {
+    fn ddl_changes(&self, parsed_line: &ParsedLine) -> Result<Vec<DdlChange>> {
         let new_column_info = &parsed_line.column_info_set().unwrap();
         let old_column_info = match self.column_info.clone() {
             Some(column_info) => column_info,
@@ -444,11 +468,7 @@ impl Table {
                 .map(|info| info.name.clone())
                 .collect_vec()
         {
-            panic!(
-                "changes to column type from: {:?} to {:?}",
-                parsed_line.column_info_set(),
-                &self.column_info
-            )
+            Err(ChangeProcessingError{ message: format!("changes to column type from: {:?} to {:?}", parsed_line.column_info_set(), &self.column_info), parsed_line: Some(parsed_line.clone()), source_line: None })
         } else {
             let mut added_ddl = new_column_info
                 .difference(&old_column_info)
@@ -459,7 +479,7 @@ impl Table {
                 .map(|info| DdlChange::RemoveColumn(info.clone(), self.table_name.clone()))
                 .collect::<Vec<_>>();
             added_ddl.extend(removed_ddl);
-            added_ddl
+            Ok(added_ddl)
         }
     }
 
@@ -481,15 +501,19 @@ impl TableHolder {
         &mut self,
         parsed_line: ParsedLine,
         targets_tables_column_names: &TargetsTablesColumnNames,
-    ) -> Option<(Table, Option<Vec<DdlChange>>)> {
+    ) -> Result<Option<(Table, Option<Vec<DdlChange>>)>> {
         if let ParsedLine::ChangedData { ref table_name, .. } = parsed_line {
             // these are cheap since this is an interned string
-            self.tables
-                .entry(table_name.clone())
-                .or_insert_with(|| Table::new(&parsed_line, targets_tables_column_names))
-                .add_change(parsed_line)
+            let entry = self.tables.entry(table_name.clone());
+            match entry {
+                Occupied(entry_value) => Ok(entry_value.get().add_change(parsed_line)?),
+                Vacant(entry_value) => {
+                    let new_table = Table::new(&parsed_line, targets_tables_column_names)?;
+                    Ok(entry_value.insert(new_table).add_change(parsed_line)?)
+                }
+            }
         } else {
-            None
+            Ok(None)
         }
     }
 
@@ -538,16 +562,16 @@ impl ChangeProcessing {
         }
         self.associated_wal_file = associated_wal_file;
     }
-    pub fn add_change(&mut self, parsed_line: ParsedLine) -> Option<Vec<ChangeProcessingResult>> {
+    pub fn add_change(&mut self, parsed_line: ParsedLine) -> Result<Option<Vec<ChangeProcessingResult>>> {
         match parsed_line {
             ParsedLine::Begin(_)
             | ParsedLine::Commit(_)
-            | ParsedLine::PgRcvlogicalMsg(_) => None,
-            ParsedLine::ContinueParse => None, // need to be exhaustive
+            | ParsedLine::PgRcvlogicalMsg(_) => Ok(None),
+            ParsedLine::ContinueParse => Ok(None), // need to be exhaustive
             ParsedLine::ChangedData { .. } => {
                 // map here maps over the option
                 // NOTE: this means that we must return a table if we want to return a ddl result
-                self.table_holder.add_change(parsed_line, &self.targets_tables_column_names).map(
+                Ok(self.table_holder.add_change(parsed_line, &self.targets_tables_column_names)?.map(
                     |(returned_table, maybe_ddl_changes)| {
                         let mut start_vec = vec![ChangeProcessingResult::TableChanges(
                             Self::write_files_for_table(
@@ -569,7 +593,7 @@ impl ChangeProcessing {
                         }
                         start_vec
                     },
-                )
+                ))
             }
         }
     }
@@ -658,6 +682,14 @@ fn column_info_has_ddl_changes_compared_to_target(
     column_names != column_names_from_target
 }
 
+fn fail_processing_if_unequal(left: usize, right: usize, message: &str) -> std::result::Result<(), ChangeProcessingError> {
+    if left != right {
+        Err(ChangeProcessingError { parsed_line: None, message: message.to_string(), source_line: None })
+    } else {
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -740,10 +772,10 @@ mod tests {
         change_processing.register_wal_file(Some(new_wal_file()));
         let blank_stats_hash = hashmap!();
         assert_eq!(change_processing.get_stats(), blank_stats_hash);
-        let mut first_result = change_processing.add_change(first_change);
+        let mut first_result = change_processing.add_change(first_change).expect("Failed processing changes");
         let single_entry_stats_hash = hashmap!(&table_name => 1);
         assert_eq!(change_processing.get_stats(), single_entry_stats_hash);
-        let second_result = change_processing.add_change(second_change);
+        let second_result = change_processing.add_change(second_change).expect("Failed processing changes");
         let double_entry_stats_hash = hashmap!(&table_name => 2);
         assert_eq!(change_processing.get_stats(), double_entry_stats_hash);
         assert!(first_result.is_some());
@@ -818,10 +850,10 @@ mod tests {
         change_processing.register_wal_file(Some(new_wal_file()));
         let blank_stats_hash = hashmap!();
         assert_eq!(change_processing.get_stats(), blank_stats_hash);
-        let mut first_result = change_processing.add_change(first_change);
+        let mut first_result = change_processing.add_change(first_change).expect("Failed processing changes");
         let single_entry_stats_hash = hashmap!(&table_name => 1);
         assert_eq!(change_processing.get_stats(), single_entry_stats_hash);
-        let second_result = change_processing.add_change(second_change);
+        let second_result = change_processing.add_change(second_change).expect("Failed processing changes");
         let double_entry_stats_hash = hashmap!(&table_name => 2);
         assert_eq!(change_processing.get_stats(), double_entry_stats_hash);
         assert!(first_result.is_some());
@@ -888,7 +920,7 @@ mod tests {
         change_processing.register_wal_file(Some(new_wal_file()));
         let blank_stats_hash = hashmap!();
         assert_eq!(change_processing.get_stats(), blank_stats_hash);
-        let first_result = change_processing.add_change(first_change);
+        let first_result = change_processing.add_change(first_change).expect("Failed processing changes");
         let single_entry_stats_hash = hashmap!(&table_name => 1);
         assert_eq!(change_processing.get_stats(), single_entry_stats_hash);
         assert!(first_result.is_none());
@@ -950,13 +982,13 @@ mod tests {
         change_processing.register_wal_file(Some(new_wal_file()));
         let blank_stats_hash = hashmap!();
         assert_eq!(change_processing.get_stats(), blank_stats_hash);
-        let first_result = change_processing.add_change(first_change);
+        let first_result = change_processing.add_change(first_change).expect("Failed processing changes");
         let single_entry_stats_hash = hashmap!(&table_name => 1);
         assert_eq!(change_processing.get_stats(), single_entry_stats_hash);
-        let mut second_result = change_processing.add_change(second_change);
+        let mut second_result = change_processing.add_change(second_change).expect("Failed processing changes");
         // we popped a record off, and then added another record, so should still have 1 in there
         assert_eq!(change_processing.get_stats(), single_entry_stats_hash);
-        let third_result = change_processing.add_change(third_change);
+        let third_result = change_processing.add_change(third_change).expect("Failed processing changes");
         let double_entry_stats_hash = hashmap!(&table_name => 2);
         assert_eq!(change_processing.get_stats(), double_entry_stats_hash);
         assert!(first_result.is_none());
@@ -1036,13 +1068,13 @@ mod tests {
         change_processing.register_wal_file(Some(new_wal_file()));
         let blank_stats_hash = hashmap!();
         assert_eq!(change_processing.get_stats(), blank_stats_hash);
-        let first_result = change_processing.add_change(first_change);
+        let first_result = change_processing.add_change(first_change).expect("Failed processing changes");
         let single_entry_stats_hash = hashmap!(&table_name => 1);
         assert_eq!(change_processing.get_stats(), single_entry_stats_hash);
-        let mut second_result = change_processing.add_change(second_change);
+        let mut second_result = change_processing.add_change(second_change).expect("Failed processing changes");
         // we popped a record off, and then added another record, so should still have 1 in there
         assert_eq!(change_processing.get_stats(), single_entry_stats_hash);
-        let third_result = change_processing.add_change(third_change);
+        let third_result = change_processing.add_change(third_change).expect("Failed processing changes");
         let double_entry_stats_hash = hashmap!(&table_name => 2);
         assert_eq!(change_processing.get_stats(), double_entry_stats_hash);
         assert!(first_result.is_none());
@@ -1144,13 +1176,13 @@ mod tests {
         change_processing.register_wal_file(Some(new_wal_file()));
         let blank_stats_hash = hashmap!();
         assert_eq!(change_processing.get_stats(), blank_stats_hash);
-        let first_result = change_processing.add_change(first_change);
+        let first_result = change_processing.add_change(first_change).expect("Failed processing changes");
         let single_entry_stats_hash = hashmap!(&table_name => 1);
         assert_eq!(change_processing.get_stats(), single_entry_stats_hash);
-        let mut second_result = change_processing.add_change(second_change);
+        let mut second_result = change_processing.add_change(second_change).expect("Failed processing changes");
         // we popped a record off, and then added another record, so should still have 1 in there
         assert_eq!(change_processing.get_stats(), single_entry_stats_hash);
-        let third_result = change_processing.add_change(third_change);
+        let third_result = change_processing.add_change(third_change).expect("Failed processing changes");
         let double_entry_stats_hash = hashmap!(&table_name => 2);
         assert_eq!(change_processing.get_stats(), double_entry_stats_hash);
         assert!(first_result.is_none());
@@ -1212,7 +1244,7 @@ mod tests {
         };
         let mut change_processing =
             ChangeProcessing::new(TargetsTablesColumnNames::from_map(HashMap::new()));
-        let result_1 = change_processing.add_change(change_1);
+        let result_1 = change_processing.add_change(change_1).expect("Failed processing changes");
         let mut expected_changes_1 = BTreeMap::<i64, ChangeSet>::new();
         expected_changes_1.insert(
             1,
@@ -1260,7 +1292,7 @@ mod tests {
             table_name: table_name.clone(),
             columns: changed_columns_2,
         };
-        let result_2 = change_processing.add_change(change_2);
+        let result_2 = change_processing.add_change(change_2).expect("Failed processing changes");
         let mut expected_changes_2 = BTreeMap::<i64, ChangeSet>::new();
         expected_changes_2.insert(
             1,
@@ -1302,7 +1334,7 @@ mod tests {
             table_name: table_name.clone(),
             columns: changed_columns_3,
         };
-        let result_3 = change_processing.add_change(change_3);
+        let result_3 = change_processing.add_change(change_3).expect("Failed processing changes");
         let mut expected_changes_3 = BTreeMap::<i64, ChangeSet>::new();
         expected_changes_3.insert(1, ChangeSet { changes: None });
         let expected_change_set_3 = ChangeSetWithColumnType::IntColumnType(expected_changes_3);
@@ -1497,7 +1529,7 @@ mod tests {
         };
         let mut change_processing =
             ChangeProcessing::new(TargetsTablesColumnNames::from_map(HashMap::new()));
-        let result_1 = change_processing.add_change(change_1);
+        let result_1 = change_processing.add_change(change_1).expect("Failed processing changes");
         let mut expected_changes_1 = BTreeMap::<i64, ChangeSet>::new();
         expected_changes_1.insert(
             1,
@@ -1545,7 +1577,7 @@ mod tests {
             table_name: table_name.clone(),
             columns: changed_columns_2,
         };
-        let result_2 = change_processing.add_change(change_2);
+        let result_2 = change_processing.add_change(change_2).expect("Failed processing changes");
         let mut expected_changes_2 = BTreeMap::<i64, ChangeSet>::new();
         expected_changes_2.insert(
             1,
@@ -1587,7 +1619,7 @@ mod tests {
             table_name: table_name.clone(),
             columns: changed_columns_3,
         };
-        let result_3 = change_processing.add_change(change_3);
+        let result_3 = change_processing.add_change(change_3).expect("Failed processing changes");
         let mut expected_changes_3 = BTreeMap::<i64, ChangeSet>::new();
         expected_changes_3.insert(
             1,
@@ -1659,7 +1691,7 @@ mod tests {
         };
         let mut change_processing =
             ChangeProcessing::new(TargetsTablesColumnNames::from_map(HashMap::new()));
-        let result_1 = change_processing.add_change(change_1);
+        let result_1 = change_processing.add_change(change_1).expect("Failed processing changes");
         let mut expected_changes_1 = BTreeMap::<i64, ChangeSet>::new();
         expected_changes_1.insert(
             1,
@@ -1706,7 +1738,7 @@ mod tests {
             table_name: table_name.clone(),
             columns: changed_columns_2,
         };
-        let result_2 = change_processing.add_change(change_2);
+        let result_2 = change_processing.add_change(change_2).expect("Failed processing changes");
         let mut expected_changes_2 = BTreeMap::<i64, ChangeSet>::new();
         expected_changes_2.insert(
             1,
@@ -1763,7 +1795,7 @@ mod tests {
         };
         let mut change_processing =
             ChangeProcessing::new(TargetsTablesColumnNames::from_map(HashMap::new()));
-        let result_1 = change_processing.add_change(change_1);
+        let result_1 = change_processing.add_change(change_1).expect("Failed processing changes");
         let mut expected_changes_1 = BTreeMap::<i64, ChangeSet>::new();
         expected_changes_1.insert(
             1,
@@ -1810,7 +1842,7 @@ mod tests {
             table_name: table_name.clone(),
             columns: changed_columns_2,
         };
-        let result_2 = change_processing.add_change(change_2);
+        let result_2 = change_processing.add_change(change_2).expect("Failed processing changes");
         let mut expected_changes_2 = BTreeMap::<i64, ChangeSet>::new();
         expected_changes_2.insert(
             1,
@@ -1866,7 +1898,7 @@ mod tests {
         };
         let mut change_processing =
             ChangeProcessing::new(TargetsTablesColumnNames::from_map(HashMap::new()));
-        let result_1 = change_processing.add_change(change_1);
+        let result_1 = change_processing.add_change(change_1).expect("Failed processing changes");
         let mut expected_changes_1 = BTreeMap::<i64, ChangeSet>::new();
         expected_changes_1.insert(
             1,
@@ -1912,7 +1944,7 @@ mod tests {
             table_name: table_name.clone(),
             columns: changed_columns_2,
         };
-        let result_2 = change_processing.add_change(change_2);
+        let result_2 = change_processing.add_change(change_2).expect("Failed processing changes");
         let mut expected_changes_2 = BTreeMap::<i64, ChangeSet>::new();
         expected_changes_2.insert(
             1,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -77,9 +77,9 @@ struct ParserState {
 }
 
 #[derive(Debug)]
-struct ParsingError {
-    line: String,
-    message: String,
+pub struct ParsingError {
+    pub line: String,
+    pub message: String,
 }
 
 impl Error for ParsingError {}
@@ -378,22 +378,22 @@ impl ColumnValue {
         string: &'a str,
         column_type: &str,
         continue_parse: bool,
-    ) -> (Option<ColumnValue>, &'a str) {
+    ) -> Result<(Option<ColumnValue>, &'a str)> {
         const NULL_STRING: &str = "null";
         if string.starts_with(NULL_STRING) {
             let (_start, rest) = ColumnValue::split_until_char_or_end(string, ' ');
-            (None, rest)
+            Ok((None, rest))
         } else {
             let (column_value, rest_of_string): (ColumnValue, &str) =
                 match Self::column_type_for_str(column_type) {
-                    ColumnTypeEnum::Integer => ColumnValue::parse_integer(string),
-                    ColumnTypeEnum::Boolean => ColumnValue::parse_boolean(string),
+                    ColumnTypeEnum::Integer => ColumnValue::parse_integer(string)?,
+                    ColumnTypeEnum::Boolean => ColumnValue::parse_boolean(string)?,
                     ColumnTypeEnum::Numeric => ColumnValue::parse_numeric(string),
                     ColumnTypeEnum::RoundingNumeric => ColumnValue::parse_rounding_numeric(string),
-                    ColumnTypeEnum::Text => ColumnValue::parse_text(string, continue_parse),
-                    ColumnTypeEnum::Timestamp => ColumnValue::parse_text(string, continue_parse),
+                    ColumnTypeEnum::Text => ColumnValue::parse_text(string, continue_parse)?,
+                    ColumnTypeEnum::Timestamp => ColumnValue::parse_text(string, continue_parse)?,
                 };
-            (Some(column_value), rest_of_string)
+            Ok((Some(column_value), rest_of_string))
         }
     }
 
@@ -420,31 +420,30 @@ impl ColumnValue {
             _ => panic!("Unknown column type: {:?}", column_type_str),
         }
     }
-    fn parse_integer<'a>(string: &'a str) -> (ColumnValue, &'a str) {
+    fn parse_integer<'a>(string: &'a str) -> Result<(ColumnValue, &'a str)> {
         let (start, rest) = ColumnValue::split_until_char_or_end(string, ' ');
-        let integer: i64 = start
-            .parse()
-            .expect("Unable to parse integer from integer type");
-        (ColumnValue::Integer(integer), rest)
+        match start.parse() {
+            Ok(integer) => Ok((ColumnValue::Integer(integer), rest)),
+            Err(internal_message) => Err(ParsingError{ message: format!("Unable to parse integer from integer type for {}, message: {}", start, internal_message), line: string.to_string() })
+        }
     }
-    fn parse_text<'a>(string: &'a str, continue_parse: bool) -> (ColumnValue, &'a str) {
+    fn parse_text<'a>(string: &'a str, continue_parse: bool) -> Result<(ColumnValue, &'a str)> {
         if string.starts_with("unchanged-toast-datum") {
             let (start, rest) = ColumnValue::split_until_char_or_end(string, ' ');
-            assert_eq!(
+            fail_parse_if_unequal(
                 start, "unchanged-toast-datum",
-                "expected 'unchanged-toast-datum' at start of string, got: `{}` when parsing `{}`",
-                start, string
-            );
-            return (ColumnValue::UnchangedToast, rest);
+                format!("expected 'unchanged-toast-datum' at start of string, got: `{}`", start),
+                string
+            )?;
+            return Ok((ColumnValue::UnchangedToast, rest));
         }
         if !continue_parse {
-            assert_eq!(
+            fail_parse_if_unequal(
                 &string[0..1],
                 "'",
-                "expected ', got `{}` when parsing `{}`",
-                &string[0..1],
+                format!("expected ', got `{}`", &string[0..1]),
                 string
-            );
+            )?;
         }
         let mut total_index: usize = 0;
         let mut complete_text: bool = false;
@@ -476,19 +475,18 @@ impl ColumnValue {
         let (start, end) = without_first_quote.split_at(total_index);
         // move past final quote if found
         let (column, text) = if complete_text {
-            assert_eq!(
+            fail_parse_if_unequal(
                 &end[0..1],
                 "'",
-                "expected ', got `{}` when parsing `{}`",
-                &end[0..1],
+                format!("expected ', got `{}`", &end[0..1]),
                 string
-            );
+            )?;
             (ColumnValue::Text(start.to_owned()), &end[1..])
         } else {
             (ColumnValue::IncompleteText(start.to_owned()), end)
         };
         let (_thrown_away_space, adjusted_end) = ColumnValue::split_until_char_or_end(text, ' ');
-        (column, adjusted_end)
+        Ok((column, adjusted_end))
     }
     fn split_until_char_or_end(string: &str, character: char) -> (&str, &str) {
         match string.split_once(character) {
@@ -506,14 +504,13 @@ impl ColumnValue {
         (ColumnValue::RoundingNumeric(start.to_owned()), rest)
     }
 
-    fn parse_boolean<'a>(string: &'a str) -> (ColumnValue, &'a str) {
+    fn parse_boolean<'a>(string: &'a str) -> Result<(ColumnValue, &'a str)> {
         let (start, rest) = ColumnValue::split_until_char_or_end(string, ' ');
-        let bool_value = match start {
-            "true" => true,
-            "false" => false,
-            _ => panic!("Unknown boolvalue {:?}", start),
-        };
-        (ColumnValue::Boolean(bool_value), rest)
+        match start {
+            "true" => Ok((ColumnValue::Boolean(true), rest)),
+            "false" => Ok((ColumnValue::Boolean(false), rest)),
+            _ => Err(ParsingError{ message: format!("Unknown boolvalue {:?}", start), line: string.to_string() })
+        }
     }
 }
 
@@ -615,7 +612,7 @@ impl Parser {
         let string_without_kind =
             &string_without_table[kind_string.len() + 2..string_without_table.len()];
 
-        let columns = self.parse_columns(string_without_kind, table_name.clone());
+        let columns = self.parse_columns(string_without_kind, table_name.clone())?;
         self.handle_parse_changed_data(table_name, kind, columns)
     }
 
@@ -648,7 +645,7 @@ impl Parser {
         }
     }
 
-    fn parse_columns(&self, string: &str, table_name: TableName) -> Vec<Column> {
+    fn parse_columns(&self, string: &str, table_name: TableName) -> Result<Vec<Column>> {
         let mut column_vector = Vec::new();
         let mut remaining_string = string;
         while remaining_string.len() > 0 {
@@ -663,28 +660,29 @@ impl Parser {
                 );
             } else {
                 let (column, rest_of_string) =
-                    self.parse_column(remaining_string, table_name.clone());
+                    self.parse_column(remaining_string, table_name.clone())?;
                 remaining_string = rest_of_string;
                 column_vector.push(column);
             }
         }
-        column_vector
+        Ok(column_vector)
     }
 
-    fn parse_column<'a>(&self, string: &'a str, _table_name: TableName) -> (Column, &'a str) {
+    fn parse_column<'a>(&self, string: &'a str, _table_name: TableName) -> Result<(Column, &'a str)> {
         let re = &PARSE_COLUMN_REGEX;
-        let captures = re
-            .captures(string)
-            .expect("Unable to match PARSE_COLUMN_REGEX to line");
+        let captures = match re.captures(string) {
+            Some(result) => result,
+            None => return Err(ParsingError{ message: "Unable to match PARSE_COLUMN_REGEX to line".to_string(), line: string.to_string() })
+        };
 
-        let column_name = captures
-            .get(1)
-            .expect("couldn't match column_name")
-            .as_str();
-        let column_type = captures
-            .get(2)
-            .expect("couldn't match column_type")
-            .as_str();
+        let column_name = match captures.get(1) {
+            Some(result) => result.as_str(),
+            None => return Err(ParsingError{ message: "couldn't match column_name".to_string(), line: string.to_string() })
+        };
+        let column_type = match captures.get(2) {
+            Some(result) => result.as_str(),
+            None => return Err(ParsingError{ message: "couldn't match column_type".to_string(), line: string.to_string() })
+        };
         // For array types, remove the inner type specification - we treat all array types as text
         let column_type = &COLUMN_TYPE_REGEX
             .replace_all(column_type, "array")
@@ -699,7 +697,7 @@ impl Parser {
         // );
 
         let (column_value, rest) =
-            ColumnValue::parse(string_without_column_type, column_type, false);
+            ColumnValue::parse(string_without_column_type, column_type, false)?;
         let column_info = ColumnInfo::new(column_name, column_type);
         let column = match column_value {
             Some(ColumnValue::UnchangedToast) => Column::UnchangedToastColumn {
@@ -719,7 +717,7 @@ impl Parser {
         //     Some(&table_name),
         //     &format!("column_parsed:{:?}", column)
         // );
-        (column, rest)
+        Ok((column, rest))
     }
 
     // TODO break this monster up a bit
@@ -732,16 +730,17 @@ impl Parser {
                 table_name,
                 mut columns,
             }) => {
-                let incomplete_column = columns
-                    .pop()
-                    .expect("error: continue parse called without any columns? wtf?");
+                let incomplete_column = match columns.pop() {
+                    Some(result) => result,
+                    None => return Err(ParsingError{ message: "error: continue parse called without any columns? wtf?".to_string(), line: string.to_string() })
+                };
                 assert!(matches!(incomplete_column, Column::IncompleteColumn { .. }));
                 match incomplete_column {
                     Column::IncompleteColumn { column_info: ColumnInfo{name, column_type}, value: incomplete_value } => {
-                        let (continued_column_value, rest) = ColumnValue::parse(string, &column_type, true);
+                        let (continued_column_value, rest) = ColumnValue::parse(string, &column_type, true)?;
                         let value = match incomplete_value {
                             ColumnValue::IncompleteText(value) => value,
-                            _ => panic!("Incomplete value is not ColumnValue::IncompleteText")
+                            _ => return Err(ParsingError{ message: "Incomplete value is not ColumnValue::IncompleteText".to_string(), line: string.to_string() })
                         };
 
                         let updated_column = match continued_column_value {
@@ -754,7 +753,7 @@ impl Parser {
                                 let column_value = ColumnValue::IncompleteText(value + "\n" + &string);
                                 Column::IncompleteColumn {column_info: ColumnInfo {name, column_type}, value: column_value}
                             },
-                            _ => panic!("Trying to continue to parse a value that's not of type text")
+                            _ => return Err(ParsingError{ message: "Trying to continue to parse a value that's not of type text".to_string(), line: string.to_string() })
                         };
 
                         columns.push(updated_column);
@@ -762,19 +761,16 @@ impl Parser {
                         if self.column_is_incomplete(&columns) {
                             return self.handle_parse_changed_data(table_name, kind, columns)
                         } else {
-                            let mut more_columns = self.parse_columns(rest, table_name.clone());
+                            let mut more_columns = self.parse_columns(rest, table_name.clone())?;
                             // append modifies in place
                             columns.append(&mut more_columns);
                             self.handle_parse_changed_data(table_name, kind, columns)
                         }
                     },
-                    _ => panic!("trying to parse an incomplete_column that's not a Column::IncompleteColumn {:?}", incomplete_column)
+                    _ => return Err(ParsingError{ message: format!("trying to parse an incomplete_column that's not a Column::IncompleteColumn {:?}", incomplete_column), line: string.to_string() })
                 }
             }
-            _ => panic!(
-                "Trying to continue parsing a {:?} rather than a ParsedLine::ChangedData",
-                incomplete_change
-            ),
+            _ => return Err(ParsingError{ message: format!("Trying to continue parsing a {:?} rather than a ParsedLine::ChangedData", incomplete_change), line: string.to_string() })
         }
     }
 


### PR DESCRIPTION
## What

- Change the `parser.rs` and `change_processing.rs` files to minimise the use of `panic!` and `expect` and instead use `Result` types to indicate a parsing or processing error
- Change `main.rs` to trigger a shutdown in the case that we fail parsing or processing changes, but continue to read from the buffer until it is empty

## Why

If we do not clear changes off of the buffer, we lose them in the case of a panic. This was causing us to lose changes from replication, which causes inconsistencies in our reporting DB.