### PR TITLE
Ability to blacklist entire schemas

### DIFF
--- a/roles/re_dms/files/re_dms.conf.example
+++ b/roles/re_dms/files/re_dms.conf.example
@@ -32,6 +32,8 @@ SOURCE_CONNECTION_STRING=
 REPLICATION_SLOT=re_dms
 # comma separated e.g. TABLE_BLACKLIST="public.schema_migrations,public.ar_internal_metadata,some_other_schema.foobars"
 TABLE_BLACKLIST=
+# comma separated e.g. SCHEMA_BLACKLIST="public"
+SCHEMA_BLACKLIST=
 TARGET_SCHEMA_NAME=
 
 # optional


### PR DESCRIPTION
Provide the ability to configure a schema or set of schemas from which no changes will be parsed or replicated.

This is useful when you have a utility schema that you do not want replicated.