### PR TITLE
Benchmark parser and speed up

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ with_rollbar = ["rollbar", "backtrace"]
 [profile.release]
 debug = true
 
+[profile.bench]
+debug = true
+
 [dependencies]
 # general purpose tools
 itertools = "0.9"

--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ $ ansible-playbook -i hosts re_dms.yml --tags cloudwatch --extra-vars "cloudwatc
 * similar to the `file_uploader_threads` this will read from the channel, and start a new task for each distinct table name (unless a task has already been started, otherwise it will reuse the channel). It will then send the `CleoS3File` to this task, which will process each `CleoS3File` and import it into the database via the `database_writer`.
 * `main.rs` does exactly what it says on the tin and runs the input loop, sending the results onwards through the pipeline. Initial files are written synchronously (`file_writer`).
 
+## Benchmarking
+* we currently have a single benchmark, it can be run with `cargo bench`
+* BONUS: you can create a flamegraph from the benchmark with `cargo flamegraph --unit-test -- parser::tests::parsing_is_fast --bench`. You can use this to guide any optimisation you want to perform.
+
 NOTE: this isn't actually threading, it's only based on async tasks and a few event loops. I use the term thread throughout since it's conceptually simpler.
 
 ### Implementation note about TOAST-ed columns.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![feature(test)]
 #![deny(warnings)]
 
 use clap::{App, Arg};

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -710,12 +710,10 @@ impl Parser {
         Ok(column_vector)
     }
 
-    // this function matches things like `"offset"[integer]:1` giving ("offset", "integer") capture groups
-    // and `id[uuid]:"i-am-a-uuid"`, giving ("id", "uuid") capture groups
-    // note the first capture group is surrounded by optional quotes to handle the first case above,
-    // and the + inside it is made non-greedy to not eat the subsequent optional quote.
-    // this is fine as we have a literal `[` to terminate the
-    // repetition so it can't end too soon
+    // this function matches things like `"offset"[integer]:1` giving ("offset", "integer", 17) result (the 17 is the length up to the colon).
+    // and `id[uuid]:"i-am-a-uuid"`, giving ("id", "uuid", 8) result
+    // NOTE: notice that it removes quotes from offset above.
+    // NOTE: it will match `my_column[character varying[]]:` and return ("my_column", "array", 30) (note that it calls all arrays type "array")
     fn parse_column_name_and_type<'a>(&self, string: &'a str) -> Result<(&'a str, &'a str, usize)> {
         let string_find_index = string.find('[').ok_or_else(|| ParsingError {
             message: "Unable to match bracket while searching for column name".to_string(),


### PR DESCRIPTION
This seems to be a 35% increase to the parser. I just ripped out the regexes a little.

I created a tiny benchmark, and then created a flamegraph while running it. Looking at that, the regexes jumped out at me as something to optimise, so I removed them.

Run benchmarks with `cargo bench`
create flamegraph with `cargo flamegraph --unit-test -- parser::tests::parsing_is_fast --bench`

Went from:
```
test parser::tests::parsing_is_fast ... bench:     327,453 ns/iter (+/- 21,276)
```
to:
```
test parser::tests::parsing_is_fast ... bench:     213,343 ns/iter (+/- 4,959)
```
It's still not the fastest in the world, and we could probably make it faster if we used a parsing lib, but good enough.