### PR TITLE
[SRE-1679] Switch insert to use not exists 

### DIFF
--- a/src/database_writer.rs
+++ b/src/database_writer.rs
@@ -710,12 +710,13 @@ impl DatabaseWriter {
             ChangeKind::Insert => {
                 format!(
                     "insert into \"{schema_name}\".\"{table_name}\"
-                    select s.* from \"{staging_name}\" s left join \"{schema_name}\".\"{table_name}\" t
-                    on s.id = t.id
-                    where t.id is NULL",
-                    schema_name=&schema_name,
-                    table_name=&table_name,
-                    staging_name=&staging_name
+                    select s.* from \"{staging_name}\" s
+                    where not exists (
+                        select 1 from \"{schema_name}\".\"{table_name}\" t
+                        where s.id = t.id)",
+                    schema_name = &schema_name,
+                    table_name = &table_name,
+                    staging_name = &staging_name
                 )
             }
             ChangeKind::Delete => {

--- a/src/database_writer.rs
+++ b/src/database_writer.rs
@@ -351,7 +351,7 @@ impl DatabaseWriter {
             credentials_string = &credentials_string,
         );
 
-        let data_migration_queries = self.queries_for_change_kind(
+        let data_migration_query_string = self.query_for_change_kind(
             kind,
             staging_name.as_ref(),
             just_table_name.as_ref(),
@@ -423,21 +423,16 @@ impl DatabaseWriter {
                 }
             }
         }
-
-        let mut query_number = 1;
-        for data_migration_query_string in data_migration_queries {
-            self.execute_single_query(
-                &transaction,
-                data_migration_query_string.as_str(),
-                &format!("apply_changes_to_real_table: {}", query_number),
-                &kind.to_string(),
-                &remote_filepath,
-                table_name.clone(),
-                wal_file_number,
-            )
-            .await?;
-            query_number += 1;
-        }
+        self.execute_single_query(
+            &transaction,
+            data_migration_query_string.as_str(),
+            "apply_changes_to_real_table",
+            &kind.to_string(),
+            &remote_filepath,
+            table_name.clone(),
+            wal_file_number,
+        )
+        .await?;
 
         self.execute_single_query(
             &transaction,
@@ -703,42 +698,37 @@ impl DatabaseWriter {
             .join(",")
     }
 
-    fn queries_for_change_kind(
+    fn query_for_change_kind(
         &self,
         kind: &ChangeKind,
         staging_name: &str,
         table_name: &str,
         schema_name: &str,
         columns: &Vec<ColumnInfo>,
-    ) -> Vec<String> {
+    ) -> String {
         match kind {
             ChangeKind::Insert => {
-                // we're doing this to avoid any casting of the tables across the cluster, and this is likely to mitigate a failing in the redshift query planner, because it's needed even when we've diststyle all-ed our staging table
-                vec![format!(
-                    "delete from \"{staging_name}\" where id in (select id from \"{schema_name}\".\"{table_name}\" where id in (select id from \"{staging_name}\"))",
-                    schema_name=&schema_name,
-                    table_name=&table_name,
-                    staging_name=&staging_name
-                ),
                 format!(
                     "insert into \"{schema_name}\".\"{table_name}\"
-                    select s.* from \"{staging_name}\" s",
+                    select s.* from \"{staging_name}\" s left join \"{schema_name}\".\"{table_name}\" t
+                    on s.id = t.id
+                    where t.id is NULL",
                     schema_name=&schema_name,
                     table_name=&table_name,
                     staging_name=&staging_name
-                )]
+                )
             }
             ChangeKind::Delete => {
-                vec![format!(
+                format!(
                     "delete from \"{schema_name}\".\"{table_name}\" where id in (select id from \"{staging_name}\")",
                     schema_name=&schema_name,
                     table_name=&table_name,
                     staging_name=&staging_name
-                )]
+                )
             }
             ChangeKind::Update => {
                 // Don't update the id column
-                vec![format!(
+                format!(
                     "
                     update \"{schema_name}\".\"{table_name}\" t
                     set {columns_to_update} from \"{staging_name}\" s
@@ -754,7 +744,7 @@ impl DatabaseWriter {
                         .collect::<Vec<_>>()
                         .join(","),
                     staging_name = &staging_name
-                )]
+                )
             }
         }
     }

--- a/src/database_writer.rs
+++ b/src/database_writer.rs
@@ -429,7 +429,7 @@ impl DatabaseWriter {
             self.execute_single_query(
                 &transaction,
                 data_migration_query_string.as_str(),
-                &format!("apply_changes_to_real_table_{}", query_number),
+                &format!("apply_changes_to_real_table: {}", query_number),
                 &kind.to_string(),
                 &remote_filepath,
                 table_name.clone(),


### PR DESCRIPTION
We all know that switching to a correlated subquery is the magic bullet for fixing all planner problems.

Should give us a plan like this:

```
XN Hash Left Join DS_BCAST_INNER  (cost=179315284.44..193715288.34 rows=120 width=602)
  Hash Cond: ("outer".oid = "inner".oid)
  Filter: ("inner".oid IS NULL)
  ->  XN Seq Scan on temp_jf_balance_snapshots s  (cost=0.00..1.20 rows=120 width=606)
  ->  XN Hash  (cost=179315284.14..179315284.14 rows=120 width=4)
        ->  XN Subquery Scan volt_dt_1  (cost=179315278.74..179315284.14 rows=120 width=4)
              ->  XN Unique  (cost=179315278.74..179315282.94 rows=120 width=4)
                    ->  XN Hash Join DS_DIST_ALL_NONE  (cost=179315278.74..179315282.64 rows=120 width=4)
                          Hash Cond: (("outer".id)::text = ("inner".id)::text)
                          ->  XN Subquery Scan volt_dt_2  (cost=179315277.24..179315278.44 rows=120 width=72)
                                ->  XN HashAggregate  (cost=179315277.24..179315277.24 rows=120 width=72)
                                      ->  XN Hash Join DS_DIST_ALL_NONE  (cost=1.50..179315276.94 rows=120 width=72)
                                            Hash Cond: (("outer".id)::text = ("inner".id)::text)
                                            ->  XN Seq Scan on balance_snapshots t  (cost=0.00..79695677.44 rows=7969567744 width=40)
                                            ->  XN Hash  (cost=1.20..1.20 rows=120 width=72)
                                                  ->  XN Seq Scan on temp_jf_balance_snapshots s  (cost=0.00..1.20 rows=120 width=72)
                          ->  XN Hash  (cost=1.20..1.20 rows=120 width=76)
                                ->  XN Seq Scan on temp_jf_balance_snapshots s  (cost=0.00..1.20 rows=120 width=76)
```

Which should be an improvement on the `left join` we were using:

```
XN Hash Right Join DS_DIST_BOTH  (cost=1.50..956354881956475.00 rows=796962100 width=602)
  Outer Dist Key: t.id
  Inner Dist Key: s.id
  Hash Cond: (("outer".id)::text = ("inner".id)::text)
  Filter: ("outer".id IS NULL)
  ->  XN Seq Scan on balance_snapshots t  (cost=0.00..79696209.92 rows=7969620992 width=40)
  ->  XN Hash  (cost=1.20..1.20 rows=120 width=602)
        ->  XN Seq Scan on temp_jf_balance_snapshots s  (cost=0.00..1.20 rows=120 width=602)
```