### PR TITLE
PLT-NO-REF fix compilation errors for current rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,9 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
+checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
 dependencies = [
  "autocfg",
  "num-integer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ env_logger = "0.8.2"
 csv = "1.1"
 glob = "0.3.0"
 bigdecimal = "0.2.0"
-num-bigint = "0.3.0" # same version as used in bigdecimal above
+num-bigint = "0.3.3" # same version as used in bigdecimal above
 
 # dotenv
 dotenv = "0.15.0"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -921,7 +921,6 @@ impl Parser {
             let schema_name: String = table_name
                 .original_schema_and_table_name()
                 .0
-                .clone()
                 .to_string();
             if TABLE_BLACKLIST.contains(table_name.as_ref()) {
                 logger_debug!(


### PR DESCRIPTION
re_dms does not build in the current version of Rust (which is what we get when building the docker image).

There are two issues: 

- a failure to build a dependency, `num-bigint=0.3.2`, which is fixed by upgrading to 0.3.3 (https://github.com/rust-num/num-bigint/blob/HEAD/RELEASES.md#release-033-2021-09-03)
- a new warning about a useless `clone()` call, which is fixed by removing it