### PR TITLE
Fix incomplete writes on panic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -296,6 +296,15 @@ async fn main_impl() -> Result<(),()> {
             }
         }
 
+        // NOTE: here we exit the main loop (impl), during a messy shutdown without
+        // `await`-ing the result of the futures `spawn`-ed within our file_uploader_threads
+        // or our database_uploader_threads.
+        // [the docs](https://docs.rs/tokio/1.35.1/tokio/runtime/struct.Runtime.html#multi-thread-scheduler)
+        // say that spawned tasks will continue running after `main_impl` returns.
+        // This should mean, that when we exit the program right after, the spawned tasks are all cancelled
+        // (if they've not already finished, we do exit all of the loops anyways during messy shutdown)
+        // this is the behaviour that we want, so it's all good.
+        // (all tasks either stop themselves, or are terminated on shutdown hereafter)
         panic_if_messy_shutdown()?;
         logger_info!(None, None, "exitted_main_loop");
 

--- a/src/wal_file_manager.rs
+++ b/src/wal_file_manager.rs
@@ -165,7 +165,7 @@ impl WalFile {
 
     fn write(&mut self, string: &str) {
         self.with_locked_internal_file()
-            .write(format!("{}\n", string).as_bytes())
+            .write_all(format!("{}\n", string).as_bytes())
             .expect("Unable to write line to wal_file");
     }
     pub fn flush(&mut self) {


### PR DESCRIPTION
I tested the exit code changes by removing most of main, and checking we returned 0 and 1 in each case.
I spent a while double checking the docs for the behaviour of tokio on shutdown after we exit, which is outlined in c9fd9a6.