### PR TITLE
Feature switch to stable rust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN set -eux; \
     url="https://static.rust-lang.org/rustup/dist/${rustArch}/rustup-init"; \
     wget "$url"; \
     chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --default-toolchain nightly; \
+    ./rustup-init -y --no-modify-path --default-toolchain stable; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ deploy: build
 	cp bin/re_dms roles/re_dms/files/re_dms
 	ansible-playbook -i hosts re_dms.yml --tags re_dms
 
+deploy_with_config: build
+	cp bin/re_dms roles/re_dms/files/re_dms
+	ansible-playbook -i hosts re_dms.yml --tags "re_dms,copy_config"
+
 clean:
 	rm -rf bin
 	rm -rf roles/re_dms/files/re_dms

--- a/README.md
+++ b/README.md
@@ -155,10 +155,6 @@ $ ansible-playbook -i hosts re_dms.yml --tags cloudwatch --extra-vars "cloudwatc
 * similar to the `file_uploader_threads` this will read from the channel, and start a new task for each distinct table name (unless a task has already been started, otherwise it will reuse the channel). It will then send the `CleoS3File` to this task, which will process each `CleoS3File` and import it into the database via the `database_writer`.
 * `main.rs` does exactly what it says on the tin and runs the input loop, sending the results onwards through the pipeline. Initial files are written synchronously (`file_writer`).
 
-## Benchmarking
-* we currently have a single benchmark, it can be run with `cargo bench`
-* BONUS: you can create a flamegraph from the benchmark with `cargo flamegraph --unit-test -- parser::tests::parsing_is_fast --bench`. You can use this to guide any optimisation you want to perform.
-
 NOTE: this isn't actually threading, it's only based on async tasks and a few event loops. I use the term thread throughout since it's conceptually simpler.
 
 ### Implementation note about TOAST-ed columns.

--- a/roles/re_dms/tasks/main.yml
+++ b/roles/re_dms/tasks/main.yml
@@ -26,6 +26,7 @@
     owner: root
     group: root
     mode: 0660
+  tags: copy_config
   notify:
     - Start re_dms
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(test)]
 #![deny(warnings)]
 
 use clap::{App, Arg};

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,3 @@
-extern crate test;
-
 use bigdecimal::BigDecimal;
 use internment::ArcIntern;
 use lazy_static::lazy_static;
@@ -1037,7 +1035,6 @@ fn fail_parse_if_unequal(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use test::Bencher;
 
     #[ctor::ctor]
     fn setup_tests() {
@@ -1444,26 +1441,5 @@ mod tests {
                 ParsedLine::Commit(3970124255)
             ]
         ))
-    }
-
-    #[bench]
-    fn parsing_is_fast(b: &mut Bencher) {
-        use std::fs::File;
-        use std::io::{self, BufRead};
-
-        let mut parser = Parser::new(true);
-        let file =
-            File::open("./test/parser.txt").expect("couldn't find file containing test data");
-        let lines = io::BufReader::new(file).lines().collect::<Vec<_>>();
-        b.iter(|| {
-            for line in &lines {
-                if let Ok(ip) = line {
-                    let parsed_line = parser
-                        .parse(&ip)
-                        .expect(&format!("failed to parse: {}", &ip));
-                    test::black_box(&parsed_line);
-                }
-            }
-        });
     }
 }


### PR DESCRIPTION
Switch to stable rust and no longer copy re_dms config by default (to allow redeploys to be simpler). Added a new make target to copy the config if we want to.