### PR TITLE
[PLT-1337] Ability to de-partition table names in target DB

### DIFF
--- a/roles/re_dms/files/re_dms.conf.example
+++ b/roles/re_dms/files/re_dms.conf.example
@@ -41,3 +41,7 @@ SENTRY_DSN=
 
 # 30 minutes, and should be less than what is set for SECONDS_UNTIL_END_OF_EXPONENTIAL_BACKOFF
 CLIENT_SIDE_DB_QUERY_TIMEOUT_IN_SECONDS=1800
+
+# A regexp you can set that will be used to replace partition suffix values from target table names
+# For example, this regexp: _p\d{4}w\d{1,2}\z would transform this source table name: webhooks_incoming_webhooks_p2024w30 to webhooks_incoming_webhooks in the target db
+PARTITION_SUFFIX_REGEXP=

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -928,12 +928,7 @@ impl Parser {
             ParsedLine::ContinueParse
         } else {
             let schema_name: String = table_name.original_schema_and_table_name().0.to_string();
-            // We need to use the target table name to ensure the table name is de-partitioned
-            let target_table_name = table_name.schema_and_table_name().1;
-            // Reconstruct the schema.table name, but using the de-partitioned table name
-            let source_schema_and_target_table_name =
-                &format!("{}.{}", schema_name, target_table_name);
-            if TABLE_BLACKLIST.contains(source_schema_and_target_table_name) {
+            if TABLE_BLACKLIST.contains(table_name.as_ref()) {
                 logger_debug!(
                     self.parse_state.wal_file_number,
                     Some(&table_name),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -931,7 +931,14 @@ impl Parser {
                 .original_schema_and_table_name()
                 .0
                 .to_string();
-            if TABLE_BLACKLIST.contains(table_name.as_ref()) {
+            // We need to use the target table name to ensure the table name is de-partitioned
+            let target_table_name = table_name.schema_and_table_name().1;
+            // Reconstruct the schema.table name, but using the de-partitioned table name
+            let source_schema_and_target_table_name = &format!(
+                "{}.{}",
+                schema_name, target_table_name
+            );
+            if TABLE_BLACKLIST.contains(source_schema_and_target_table_name) {
                 logger_debug!(
                     self.parse_state.wal_file_number,
                     Some(&table_name),


### PR DESCRIPTION
This adds a new ENV, `PARTITION_SUFFIX_REGEXP`, that, when set, will strip any matching text from the target table name.

This is needed to unblock work that involves adding a lot more partitioning in our source DB. We want to ensure this partitioning is not reflected in the target DB.

This uses the de-partitioned table name when checking tables against the `TABLE_BLACKLIST`.