### PR TITLE
[PLT-1337] Log regexp

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -569,6 +569,11 @@ impl ColumnValue {
 
 impl Parser {
     pub fn new(include_xids: bool) -> Parser {
+        logger_info!(
+            None,
+            None,
+            &format!("partition_suffix_regexp:{:?}", PARTITION_SUFFIX_REGEXP.clone().ok_or("none"))
+        );
         Parser {
             config: ParserConfig { include_xids },
             parse_state: ParserState {


### PR DESCRIPTION
Adds logging to the `PARITITON_SUFFIX_REGEXP` env var. Output looks like this:

```
[2024-08-30T11:30:54Z INFO  re_dms::logger] wal:none table:none tag:re_dms::parser::Parser::new message:partition_suffix_regexp:Ok(Regex("_p\\d{4}w\\d{1,2}\\z"))
```

Adding this because the prod application doesn't seem to be picking up the config for this value.