### PR TITLE
[PLT-XXX] Make Docker run on amd64 platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ all: build
 
 build: clean
 	mkdir -p bin
-	docker build -t re_dms .
-	docker create -ti --name re_dms re_dms bash
+	docker build --platform linux/amd64 -t re_dms .
+	docker create --platform linux/amd64 -ti --name re_dms re_dms bash
 	docker cp re_dms:/tmp/re_dms/target/release/re_dms ./bin/re_dms
 
 deploy: build


### PR DESCRIPTION
This tells Docker to run on x86-64 architecture when compiling re_dms for the target system.

Without this, it will target `ARM aarch64` if building on a mac with an arm chip. This won't executable won't be able to run on x86 targets and you get a `Failed to execute command: Exec format error` error when you try.