### PR TITLE
[PLT-2554] Multi-env re_dms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /data
 /output
 /output_wal
-/roles/re_dms/files/re_dms.conf
+/roles/re_dms/files/re_dms.conf*
 /roles/re_dms/files/re_dms
 /bin
 *.org

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-# > Start > Borrowed from: https://github.com/rust-lang/docker-rust-nightly/blob/2896708e58424ce0495c83f0364106e4f93b31bf/buster/Dockerfile
-# As of Dec, 2021, we run re_dms on Ubuntu 18.04 which has glibc 2.27. However, Rust official docker images are based on directly on Debian. Ubuntu 18.04 is based
-# on Debian Buster, however Buster runs glibc 2.28. Hence, building our executable against a Buster Debian image breaks because it expects glibc 2.28 at
-# runtime (and it's not there). We've essentially created our own Rust docker image against Ubuntu 18.04 in order to build our executable guaranteed to be compatible with our deploy target.
-FROM buildpack-deps:bionic
+FROM buildpack-deps:noble
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,20 @@ build: clean
 	docker create --platform linux/amd64 -ti --name re_dms re_dms bash
 	docker cp re_dms:/tmp/re_dms/target/release/re_dms ./bin/re_dms
 
-deploy: build
+deploy_staging: build
 	cp bin/re_dms roles/re_dms/files/re_dms
-	ansible-playbook -i hosts re_dms.yml --tags re_dms --skip-tags copy_config
+	ansible-playbook -i hosts re_dms.yml --tags re_dms --skip-tags copy_config -e "env=staging"
+
+deploy: deploy_staging
+	ansible-playbook -i hosts re_dms.yml --tags re_dms --skip-tags copy_config -e "env=production"
+
+deploy_staging_with_config: build
+	cp bin/re_dms roles/re_dms/files/re_dms
+	ansible-playbook -i hosts re_dms.yml --tags "re_dms,copy_config" -e "env=staging"
 
 deploy_with_config: build
 	cp bin/re_dms roles/re_dms/files/re_dms
-	ansible-playbook -i hosts re_dms.yml --tags "re_dms,copy_config"
+	ansible-playbook -i hosts re_dms.yml --tags "re_dms,copy_config" -e "env=production"
 
 clean:
 	rm -rf bin

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Docs on `pg_recvlogical` [here](https://www.postgresql.org/docs/10/app-pgrecvlog
     1. Writable directory (ideally with persistent storage) for keeping WAL files
     1. Ability to communicate with source and target DB
 1. SSH config for target instance, name of connection specified in `hosts` file (copy from `hosts.example`)
-1. `roles/re_dms/files/re_dms.conf.example` copied to `roles/re_dms/files/re_dms.conf`, including the following:
+1. `roles/re_dms/files/re_dms.conf.example` copied to `roles/re_dms/files/re_dms.conf.[staging|production]`, including the following:
     1. Write creds for Redshift
     1. S3 bucket for storing changes to be applied
     1. AWS creds for writing to S3 bucket

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ Docs on `pg_recvlogical` [here](https://www.postgresql.org/docs/10/app-pgrecvlog
 
 ### Pre-requisites
 
-1. Have ansible installed locally
+1. Have ansible installed locally, including the following collections (`ansible-galaxy collection install ...`):
+    - `community.general`
+    - `ansible.posix`
 1. Have Docker running locally
 1. Have a target instance with the following:
     1. Debian or Ubuntu (based on `Noble`) installed

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Docs on `pg_recvlogical` [here](https://www.postgresql.org/docs/10/app-pgrecvlog
 1. Have ansible installed locally
 1. Have Docker running locally
 1. Have a target instance with the following:
-    1. Debian or Ubuntu (based on `Buster`) installed
+    1. Debian or Ubuntu (based on `Noble`) installed
     1. Writable directory (ideally with persistent storage) for keeping WAL files
     1. Ability to communicate with source and target DB
 1. SSH config for target instance, name of connection specified in `hosts` file (copy from `hosts.example`)

--- a/hosts.example
+++ b/hosts.example
@@ -1,2 +1,5 @@
-[myservers]
-<target hostname goes here>
+[production]
+<target production hostname goes here>
+
+[staging]
+<target staging hostname goes here>

--- a/hosts.example
+++ b/hosts.example
@@ -1,5 +1,5 @@
 [production]
-<target production hostname goes here>
+<target production hostname goes here> filesystemDev=/dev/<device>
 
 [staging]
-<target staging hostname goes here>
+<target staging hostname goes here> filesystemDev=/dev/<device>

--- a/re_dms.yml
+++ b/re_dms.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: myservers
+- hosts: "{{ env }}"
   become: yes
   become_user: root
   roles:

--- a/roles/re_dms/tasks/main.yml
+++ b/roles/re_dms/tasks/main.yml
@@ -20,8 +20,8 @@
 
 - name: Copy systemd config file to server
   copy:
-    src: re_dms.conf
-    dest: /etc
+    src: "re_dms.conf.{{ env }}"
+    dest: /etc/re_dms.conf
     owner: root
     group: root
     mode: 0660

--- a/roles/re_dms/tasks/main.yml
+++ b/roles/re_dms/tasks/main.yml
@@ -18,6 +18,27 @@
     state: present
     create_home: no
 
+- name: create ext4 filesystem
+  community.general.filesystem:
+    fstype: ext4
+    dev: "{{filesystemDev}}"
+
+- name: mount filesystem
+  ansible.posix.mount:
+    path: /re_dms
+    src: "{{filesystemDev}}"
+    fstype: ext4
+    opts: rw,auto
+    state: mounted
+
+- name: create output_wal dir
+  ansible.builtin.file:
+    path: /re_dms/output_wal
+    state: directory
+    owner: re_dms
+    group: re_dms
+    mode: '0750'
+
 - name: Copy systemd config file to server
   copy:
     src: "re_dms.conf.{{ env }}"

--- a/roles/re_dms/tasks/main.yml
+++ b/roles/re_dms/tasks/main.yml
@@ -1,8 +1,7 @@
 ---
-# Needs to use client v10 https://forums.aws.amazon.com/thread.jspa?messageID=936554
 - name: Install postgresql-client
   package:
-    name: postgresql-client-10
+    name: postgresql-client
     state: present
 
 - name: create re_dms group


### PR DESCRIPTION
[Run off Ubuntu 24 (Noble)](https://github.com/meetcleo/re_dms/commit/5e2b4d3aa1e4024a1311422a7247a1edf3f7940f) 
This makes the application work from a Ubuntu 24 (Noble) base (and Postgres v16 client). This is now a possibility given that we do not require pg_recvlogical from postgres client v10. (RDS has fixed the compatibility issue that prevented upgrading in the past). Also, Bionic is no longer under support.

[Multi-stage deploy](https://github.com/meetcleo/re_dms/commit/0958988f2543d713d591ca69475fd7cf02e315d8) 
This allows for deploying to a staging environment before production.

Adding this because we want to be able to test changes in a pre-prod environment before putting them live on production.