### PR TITLE
Fix newline null bug.

### DIFF
--- a/test/parser_null_newline_bug.txt
+++ b/test/parser_null_newline_bug.txt
@@ -1,0 +1,5 @@
+BEGIN 3970124255
+table public.foobar: INSERT: baz[text]:'hello
+null and other stuff
+bye'
+COMMIT 3970124255


### PR DESCRIPTION
Fix bug with parsing when we are continuing a parse and have a newline before a null.